### PR TITLE
Added missing printer node in modules

### DIFF
--- a/js/gw.cloud.config.json
+++ b/js/gw.cloud.config.json
@@ -17,6 +17,16 @@
       "args": null
     },
     {
+      "name": "node_printer",
+      "loader": {
+        "name": "node",
+        "entrypoint": {
+          "main.path": "modules/printer.js"
+        }
+      },
+      "args": null
+    },    
+    {
       "name": "iothub_writer",
       "loader": {
         "name": "node",


### PR DESCRIPTION
Printer node is referenced in links (as a sink) but not available in modules. Took a copy from the local.json